### PR TITLE
Fix #5: Mobile underline reaches full text width (v2)

### DIFF
--- a/src/components/HomeContent.tsx
+++ b/src/components/HomeContent.tsx
@@ -118,7 +118,7 @@ export default function HomeContent({ bestsellers }: HomeContentProps) {
             <span className="relative">
               Why Desert Candle Works?
               <span className="inline-block w-0.5 h-[1em] bg-black ml-2 animate-[caretBlink_1s_step-end_infinite] rotate-12 origin-bottom"></span>
-              <span className="absolute -bottom-2 left-0 right-0 h-0.5 bg-[var(--color-accent)] opacity-0 animate-[fadeIn_1s_ease-out_0.3s_forwards]"></span>
+              <span className="absolute -bottom-2 left-0 right-0 h-0.5 bg-[var(--color-accent)] animate-[expandWidth_1s_ease-out_0.3s_forwards]"></span>
             </span>
           </h2>
         </div>

--- a/src/components/HomeContent.tsx
+++ b/src/components/HomeContent.tsx
@@ -112,14 +112,12 @@ export default function HomeContent({ bestsellers }: HomeContentProps) {
       <section className="mx-auto max-w-6xl px-6 py-16">
         <div className="text-center mb-12">
           <h2
-            className={`${megastina.className} script-title script-hero mb-8 relative text-2xl sm:text-3xl md:text-4xl lg:text-5xl`}
-            style={{ color: "var(--color-ink)", display: "inline-block", maxWidth: "min(90vw, 100%)" }}
+            className={`${megastina.className} script-title script-hero mb-8 inline-block relative`}
+            style={{ color: "var(--color-ink)" }}
           >
-            <span className="relative whitespace-nowrap">
-              Why Desert Candle Works?
-              <span className="inline-block w-0.5 h-[1em] bg-black ml-2 animate-[caretBlink_1s_step-end_infinite] rotate-12 origin-bottom"></span>
-              <span className="absolute -bottom-2 left-0 w-full h-0.5 bg-[var(--color-accent)] animate-[expandWidth_1s_ease-out_0.3s_forwards]"></span>
-            </span>
+            Why Desert Candle Works?
+            <span className="inline-block w-0.5 h-[1em] bg-black ml-2 animate-[caretBlink_1s_step-end_infinite] rotate-12 origin-bottom"></span>
+            <span className="absolute -bottom-2 left-0 right-0 h-0.5 bg-[var(--color-accent)] w-0 animate-[expandWidth_1s_ease-out_0.3s_forwards]"></span>
           </h2>
         </div>
         <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/components/HomeContent.tsx
+++ b/src/components/HomeContent.tsx
@@ -112,13 +112,13 @@ export default function HomeContent({ bestsellers }: HomeContentProps) {
       <section className="mx-auto max-w-6xl px-6 py-16">
         <div className="text-center mb-12">
           <h2
-            className={`${megastina.className} script-title script-hero mb-8 relative inline-block`}
+            className={`${megastina.className} script-title script-hero mb-8 relative inline-block text-3xl sm:text-4xl md:text-5xl`}
             style={{ color: "var(--color-ink)" }}
           >
-            <span className="relative">
+            <span className="relative inline-block">
               Why Desert Candle Works?
               <span className="inline-block w-0.5 h-[1em] bg-black ml-2 animate-[caretBlink_1s_step-end_infinite] rotate-12 origin-bottom"></span>
-              <span className="absolute -bottom-2 left-0 right-0 h-0.5 bg-[var(--color-accent)] animate-[expandWidth_1s_ease-out_0.3s_forwards]"></span>
+              <span className="absolute -bottom-2 left-0 w-full h-0.5 bg-[var(--color-accent)] animate-[expandWidth_1s_ease-out_0.3s_forwards]"></span>
             </span>
           </h2>
         </div>

--- a/src/components/HomeContent.tsx
+++ b/src/components/HomeContent.tsx
@@ -112,12 +112,12 @@ export default function HomeContent({ bestsellers }: HomeContentProps) {
       <section className="mx-auto max-w-6xl px-6 py-16">
         <div className="text-center mb-12">
           <h2
-            className={`${megastina.className} script-title script-hero mb-8 inline-block relative`}
+            className={`${megastina.className} script-title script-hero mb-8 inline-block relative max-w-full`}
             style={{ color: "var(--color-ink)" }}
           >
             Why Desert Candle Works?
             <span className="inline-block w-0.5 h-[1em] bg-black ml-2 animate-[caretBlink_1s_step-end_infinite] rotate-12 origin-bottom"></span>
-            <span className="absolute -bottom-2 left-0 right-0 h-0.5 bg-[var(--color-accent)] w-0 animate-[expandWidth_1s_ease-out_0.3s_forwards]"></span>
+            <span className="absolute -bottom-2 left-0 h-0.5 w-0 bg-[var(--color-accent)] animate-[expandWidth_1s_ease-out_0.3s_forwards]"></span>
           </h2>
         </div>
         <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/components/HomeContent.tsx
+++ b/src/components/HomeContent.tsx
@@ -112,10 +112,10 @@ export default function HomeContent({ bestsellers }: HomeContentProps) {
       <section className="mx-auto max-w-6xl px-6 py-16">
         <div className="text-center mb-12">
           <h2
-            className={`${megastina.className} script-title script-hero mb-8 relative inline-block text-3xl sm:text-4xl md:text-5xl`}
-            style={{ color: "var(--color-ink)" }}
+            className={`${megastina.className} script-title script-hero mb-8 relative text-2xl sm:text-3xl md:text-4xl lg:text-5xl`}
+            style={{ color: "var(--color-ink)", display: "inline-block", maxWidth: "min(90vw, 100%)" }}
           >
-            <span className="relative inline-block">
+            <span className="relative whitespace-nowrap">
               Why Desert Candle Works?
               <span className="inline-block w-0.5 h-[1em] bg-black ml-2 animate-[caretBlink_1s_step-end_infinite] rotate-12 origin-bottom"></span>
               <span className="absolute -bottom-2 left-0 w-full h-0.5 bg-[var(--color-accent)] animate-[expandWidth_1s_ease-out_0.3s_forwards]"></span>


### PR DESCRIPTION
Fixes issue #5 (updated after initial merge)

## Changes
- Reverted font size changes and whitespace-nowrap from previous attempt
- Using `inline-block` on h2 to shrink-wrap to content width
- Added `max-w-full` to prevent text overflow on mobile
- Underline uses `expandWidth` animation from `width: 0` to `width: 100%`
- When text wraps, h2 width matches the longest line, and underline spans that full width

## Result
- Text wraps naturally on mobile (no forced single line)
- Underline spans the full width of the longest text line
- No text overflow off the right side of the screen
- Original font sizes maintained